### PR TITLE
Diagnose and fix content column shift

### DIFF
--- a/themes/reallylol/static/css/style.css
+++ b/themes/reallylol/static/css/style.css
@@ -41,6 +41,10 @@
   box-sizing: border-box;
 }
 
+html {
+  scrollbar-gutter: stable;
+}
+
 html,
 body {
   min-height: 100vh;


### PR DESCRIPTION
Add `scrollbar-gutter: stable` to the `html` element to prevent layout shifts caused by the scrollbar appearing/disappearing.

The layout shift occurred because pages with varying content heights would sometimes trigger a vertical scrollbar and sometimes not. When a scrollbar appeared, it reduced the available viewport width, causing centered content to shift horizontally. `scrollbar-gutter: stable` reserves space for the scrollbar, ensuring consistent content positioning across all pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-99ed3616-af3a-42ef-aadc-f66975432b99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-99ed3616-af3a-42ef-aadc-f66975432b99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

